### PR TITLE
Add withdrawal amount

### DIFF
--- a/src/FeeCollector.sol
+++ b/src/FeeCollector.sol
@@ -61,10 +61,7 @@ contract FeeCollector is Owned, IFeeCollector {
 
     /// @inheritdoc IFeeCollector
     function withdrawFeeToken(address feeRecipient, uint256 amount) external onlyOwner {
-        uint256 balance = feeToken.balanceOf(address(this));
-        if (balance > 0) {
-            feeToken.safeTransfer(feeRecipient, balance);
-        }
+        feeToken.safeTransfer(feeRecipient, amount);
     }
 
     receive() external payable {}

--- a/src/interfaces/IFeeCollector.sol
+++ b/src/interfaces/IFeeCollector.sol
@@ -20,5 +20,6 @@ interface IFeeCollector {
 
     /// @notice Transfers the fee token balance from this contract to the fee recipient.
     /// @param feeRecipient The address to send the fee token balance to.
+    /// @param amount The amount to withdraw.
     function withdrawFeeToken(address feeRecipient, uint256 amount) external;
 }

--- a/test/FeeCollector.t.sol
+++ b/test/FeeCollector.t.sol
@@ -124,7 +124,7 @@ contract FeeCollectorTest is Test {
         mockFeeToken.mint(address(collector), 100 ether);
         assertEq(mockFeeToken.balanceOf(address(collector)), 100 ether);
         vm.prank(caller);
-        collector.withdrawFeeToken(feeRecipient);
+        collector.withdrawFeeToken(feeRecipient, 100 ether);
         assertEq(mockFeeToken.balanceOf(address(collector)), 0);
         assertEq(mockFeeToken.balanceOf(address(feeRecipient)), 100 ether);
     }
@@ -136,7 +136,7 @@ contract FeeCollectorTest is Test {
         assertEq(mockFeeToken.balanceOf(address(collector)), 100 ether);
         vm.expectRevert("UNAUTHORIZED");
         vm.prank(address(0xbeef));
-        collector.withdrawFeeToken(feeRecipient);
+        collector.withdrawFeeToken(feeRecipient, 100 ether);
         assertEq(mockFeeToken.balanceOf(address(collector)), 100 ether);
     }
 

--- a/test/fork/TestFeeCollector.t.sol
+++ b/test/fork/TestFeeCollector.t.sol
@@ -68,7 +68,7 @@ contract FeeCollectorTest is Test {
         // Withdraw USDC to feeRecipient
         assertEq(USDC.balanceOf(address(feeRecipient)), preSwapBalance);
         vm.prank(caller);
-        collector.withdrawFeeToken(feeRecipient);
+        collector.withdrawFeeToken(feeRecipient, collectorUSDCBalance);
         assertEq(USDC.balanceOf(address(feeRecipient)), preSwapBalance + collectorUSDCBalance);
         assertEq(USDC.balanceOf(FEE_COLLECTOR), 0);
     }
@@ -103,7 +103,7 @@ contract FeeCollectorTest is Test {
         // Withdraw USDC to feeRecipient
         assertEq(USDC.balanceOf(address(feeRecipient)), 0);
         vm.prank(caller);
-        collector.withdrawFeeToken(feeRecipient);
+        collector.withdrawFeeToken(feeRecipient, collectorUSDCBalance);
         assertEq(USDC.balanceOf(address(feeRecipient)), collectorUSDCBalance);
         assertEq(USDC.balanceOf(FEE_COLLECTOR), 0);
     }
@@ -127,7 +127,7 @@ contract FeeCollectorTest is Test {
         // Withdraw USDC to feeRecipient
         assertEq(USDC.balanceOf(address(feeRecipient)), preSwapBalance);
         vm.prank(caller);
-        collector.withdrawFeeToken(feeRecipient);
+        collector.withdrawFeeToken(feeRecipient, collectorUSDCBalance);
         assertEq(USDC.balanceOf(address(feeRecipient)), preSwapBalance + collectorUSDCBalance);
         assertEq(USDC.balanceOf(FEE_COLLECTOR), 0);
     }
@@ -159,7 +159,7 @@ contract FeeCollectorTest is Test {
         // Withdraw USDC to feeRecipient
         assertEq(USDC.balanceOf(address(feeRecipient)), preSwapBalance);
         vm.prank(caller);
-        collector.withdrawFeeToken(feeRecipient);
+        collector.withdrawFeeToken(feeRecipient, collectorUSDCBalance);
         assertEq(USDC.balanceOf(address(feeRecipient)), preSwapBalance + collectorUSDCBalance);
         assertEq(USDC.balanceOf(FEE_COLLECTOR), 0);
     }


### PR DESCRIPTION
## Summary
This PR adds an amount argument to the withdraw function. This is a change made in response to ABDK audit linked [here](https://docs.google.com/spreadsheets/d/1RKzrHCo8J1ZsfEMiC5KexWkxt9oRDlfPyNZeKdgRgW8/edit#gid=0&range=A11).

> This function always withdraws the whole balance, which could in theory be problematic for tokens with complicated transfer semantics, such as token that charge transfer fees. Consider adding an argument to specify the amount to be withdrawn. Such argument could have a special value treated as “whole balance”.

